### PR TITLE
Fix for Graph Batch API limits

### DIFF
--- a/src/GraphService.test.ts
+++ b/src/GraphService.test.ts
@@ -15,7 +15,7 @@ test("resolveProfile()", async () => {
         new Response(JSON.stringify({
             responses: [
                 {
-                    id: (await req.json()).batch[0].id,
+                    id: (await req.json()).requests[0].id,
                     body: buildProfileResponse(1),
                     status: 200
                 }
@@ -35,7 +35,7 @@ test("resolveProfile() when individual request error", async () => {
         new Response(JSON.stringify({
             responses: [
                 {
-                    id: (await req.json()).batch[0].id,
+                    id: (await req.json()).requests[0].id,
                     status: 500
                 }
             ]

--- a/src/GraphService.test.ts
+++ b/src/GraphService.test.ts
@@ -15,7 +15,7 @@ test("resolveProfile()", async () => {
         new Response(JSON.stringify({
             responses: [
                 {
-                    id: (await req.json()).requests[0].id,
+                    id: (await req.json()).batch[0].id,
                     body: buildProfileResponse(1),
                     status: 200
                 }
@@ -35,7 +35,7 @@ test("resolveProfile() when individual request error", async () => {
         new Response(JSON.stringify({
             responses: [
                 {
-                    id: (await req.json()).requests[0].id,
+                    id: (await req.json()).batch[0].id,
                     status: 500
                 }
             ]

--- a/src/GraphService.ts
+++ b/src/GraphService.ts
@@ -135,7 +135,7 @@ export module GraphService {
     async function processBatch() {
         let batchNumber = 0;
         const batchLimit = 20;
-        const requests = {
+        const batches = {
             0: []
         };
         const processingQueue = queue;
@@ -145,21 +145,21 @@ export module GraphService {
         for (const id of Object.keys(processingQueue)) {
             const req = processingQueue[id];
 
-            if (requests[batchNumber].length >= batchLimit) {
+            if (batches[batchNumber].length >= batchLimit) {
                 batchNumber += 1;
-                requests[batchNumber] = [];
+                batches[batchNumber] = [];
             }
 
-            requests[batchNumber].push({
+            batches[batchNumber].push({
                 id: req.id,
                 method: req.method,
                 url: req.url
             });
         }
 
-        // Process each batch of 20 requests
-        for (const current of Object.keys(requests)) {
-            const batch = requests[current];
+        // Process each batch of 20 requests one at a time
+        for (const current of Object.keys(batches)) {
+            const requests = batches[current];
             const adToken = await GraphServiceAuthenticator.getAuthToken();
             const batchRequest = new Request(`${graphBaseUrl}/v1.0/$batch`, {
                 method: "POST",
@@ -167,7 +167,7 @@ export module GraphService {
                     Authorization: `Bearer ${adToken}`,
                     "Content-Type": "application/json"
                 },
-                body: JSON.stringify({ batch })
+                body: JSON.stringify({ requests })
             });
 
             try {

--- a/src/supporting/Response.ts
+++ b/src/supporting/Response.ts
@@ -1,0 +1,13 @@
+import { buildProfileResponse } from "./Profile";
+
+export function buildResponse(userId: number, status: number) {
+    return new Response(JSON.stringify({
+        responses: [
+            {
+                id: userId,
+                body: buildProfileResponse(userId),
+                status: status
+            }
+        ]
+    }));
+};


### PR DESCRIPTION
This is a fix for the throttling that we receive from the Graph Batch API. We bundle our requests into arrays of 20 items at a time and process each array separately.