### PR TITLE
add screen reader info for contact details: email, phone, chat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-contact-card",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Contact Card in MS Office style",
   "repository": {
     "type": "git",

--- a/src/__snapshots__/PersonaWithCard.test.tsx.snap
+++ b/src/__snapshots__/PersonaWithCard.test.tsx.snap
@@ -283,7 +283,6 @@ exports[`renders PersonaWithCard initial state 1`] = `
   }
   instantOpenOnClick={true}
   onCardVisible={[Function]}
-  openHotKey={13}
   trapFocus={true}
 >
   <Persona
@@ -307,7 +306,6 @@ exports[`renders PersonaWithCard with extra props 1`] = `
   }
   instantOpenOnClick={true}
   onCardVisible={[Function]}
-  openHotKey={13}
   trapFocus={true}
 >
   <Persona

--- a/src/__snapshots__/PersonaWithCard.test.tsx.snap
+++ b/src/__snapshots__/PersonaWithCard.test.tsx.snap
@@ -283,6 +283,7 @@ exports[`renders PersonaWithCard initial state 1`] = `
   }
   instantOpenOnClick={true}
   onCardVisible={[Function]}
+  openHotKey={13}
   trapFocus={true}
 >
   <Persona
@@ -306,6 +307,7 @@ exports[`renders PersonaWithCard with extra props 1`] = `
   }
   instantOpenOnClick={true}
   onCardVisible={[Function]}
+  openHotKey={13}
   trapFocus={true}
 >
   <Persona

--- a/src/contactCard/ContactDetails.tsx
+++ b/src/contactCard/ContactDetails.tsx
@@ -8,18 +8,18 @@ export function renderContactDetails(profile: IPersonaProfile): React.ReactNode 
     return (
         <ul className={css("contact-details", AnimationClassNames.slideLeftIn400)}>
             <li>
-                <Label id="emailLabel">Email</Label>
-                <Link id="emailLink" href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-labelledby="emailLabel emailLink">{profile.email}</Link>
+                <Label>Email</Label>
+                <Link href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-label={`Email ${profile.email}`}>{profile.email}</Link>
             </li>
             {profile.imAddress && (
                 <li>
-                    <Label id="chatLabel">Chat</Label>
-                    <Link id="chatLink" href={`sip:${profile.imAddress}`} className="contact-link chat" onClick={e => openLink(`sip:${profile.imAddress}`, e)} aria-labelledby="chatLabel chatLink" >{profile.imAddress}</Link>
+                    <Label>Chat</Label>
+                    <Link href={`sip:${profile.imAddress}`} className="contact-link chat" onClick={e => openLink(`sip:${profile.imAddress}`, e)} aria-label={`Chat ${profile.imAddress}`}>{profile.imAddress}</Link>
                 </li>
             )}
             <li>
-                <Label id="workPhoneLabel">Work phone</Label>
-                <Link id="workPhoneLink" href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-labelledby="workPhoneLabel workPhoneLink">{profile.businessPhone}</Link>
+                <Label>Work phone</Label>
+                <Link href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-label={`Work phone ${profile.businessPhone}`}>{profile.businessPhone}</Link>
             </li>
             <li>
                 <Label>Company</Label>

--- a/src/contactCard/ContactDetails.tsx
+++ b/src/contactCard/ContactDetails.tsx
@@ -8,18 +8,18 @@ export function renderContactDetails(profile: IPersonaProfile): React.ReactNode 
     return (
         <ul className={css("contact-details", AnimationClassNames.slideLeftIn400)}>
             <li>
-                <Label>Email</Label>
-                <Link href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)}>{profile.email}</Link>
+                <Label id="emailLabel">Email</Label>
+                <Link id="emailLink" href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-labelledby="emailLabel emailLink">{profile.email}</Link>
             </li>
             {profile.imAddress && (
                 <li>
-                    <Label>Chat</Label>
-                    <Link href={`sip:${profile.imAddress}`} className="contact-link chat" onClick={e => openLink(`sip:${profile.imAddress}`, e)}>{profile.imAddress}</Link>
+                    <Label id="chatLabel">Chat</Label>
+                    <Link id="chatLink" href={`sip:${profile.imAddress}`} className="contact-link chat" onClick={e => openLink(`sip:${profile.imAddress}`, e)} aria-labelledby="chatLabel chatLink" >{profile.imAddress}</Link>
                 </li>
             )}
             <li>
-                <Label>Work phone</Label>
-                <Link href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)}>{profile.businessPhone}</Link>
+                <Label id="workPhoneLabel">Work phone</Label>
+                <Link id="workPhoneLink" href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-labelledby="workPhoneLabel workPhoneLink">{profile.businessPhone}</Link>
             </li>
             <li>
                 <Label>Company</Label>

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -30,14 +30,14 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
             </ActionButton>
 
             <div className="contact-row">
-                <Icon iconName="Mail" className="contact-icon" />
-                <Link href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)}>{profile.email}</Link>
+                <Icon id="emailIcon" iconName="Mail" className="contact-icon" aria-label="email"/>
+                <Link id="emailLink" href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-labelledby="emailIcon emailLink">{profile.email}</Link>
             </div>
             {
                 profile.businessPhone &&
                 <div className="contact-row">
-                    <Icon iconName="Phone" className="contact-icon" />
-                    <Link href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)}>{profile.businessPhone}</Link>
+                    <Icon id="phoneIcon" iconName="Phone" className="contact-icon" aria-label="phone"/>
+                    <Link id="phoneLink" href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-labelledby="phoneIcon phoneLink">{profile.businessPhone}</Link>
                 </div>
             }
             <div className="contact-row">

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -30,14 +30,14 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
             </ActionButton>
 
             <div className="contact-row">
-                <Icon id="emailIcon" iconName="Mail" className="contact-icon" aria-label="email"/>
-                <Link id="emailLink" href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-labelledby="emailIcon emailLink">{profile.email}</Link>
+                <Icon iconName="Mail" className="contact-icon" aria-label="email"/>
+                <Link href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-label={`Email ${profile.email}`}>{profile.email}</Link>
             </div>
             {
                 profile.businessPhone &&
                 <div className="contact-row">
-                    <Icon id="phoneIcon" iconName="Phone" className="contact-icon" aria-label="phone"/>
-                    <Link id="phoneLink" href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-labelledby="phoneIcon phoneLink">{profile.businessPhone}</Link>
+                    <Icon iconName="Phone" className="contact-icon" aria-label="phone"/>
+                    <Link href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-label={`Phone ${profile.businessPhone}`}>{profile.businessPhone}</Link>
                 </div>
             }
             <div className="contact-row">

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -30,13 +30,13 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
             </ActionButton>
 
             <div className="contact-row">
-                <Icon iconName="Mail" className="contact-icon"/>
+                <Icon iconName="Mail" className="contact-icon" />
                 <Link href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-label={`Email ${profile.email}`}>{profile.email}</Link>
             </div>
             {
                 profile.businessPhone &&
                 <div className="contact-row">
-                    <Icon iconName="Phone" className="contact-icon"/>
+                    <Icon iconName="Phone" className="contact-icon" />
                     <Link href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-label={`Phone ${profile.businessPhone}`}>{profile.businessPhone}</Link>
                 </div>
             }

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -30,13 +30,13 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
             </ActionButton>
 
             <div className="contact-row">
-                <Icon iconName="Mail" className="contact-icon" aria-label="email"/>
+                <Icon iconName="Mail" className="contact-icon"/>
                 <Link href={`mailto:${profile.email}`} className="contact-link email" onClick={e => openLink(`mailto:${profile.email}`, e)} aria-label={`Email ${profile.email}`}>{profile.email}</Link>
             </div>
             {
                 profile.businessPhone &&
                 <div className="contact-row">
-                    <Icon iconName="Phone" className="contact-icon" aria-label="phone"/>
+                    <Icon iconName="Phone" className="contact-icon"/>
                     <Link href={`tel:${profile.businessPhone}`} className="contact-link business-phone" onClick={e => openLink(`tel:${profile.businessPhone}`, e)} aria-label={`Phone ${profile.businessPhone}`}>{profile.businessPhone}</Link>
                 </div>
             }

--- a/src/contactCard/__snapshots__/ContactDetails.test.tsx.snap
+++ b/src/contactCard/__snapshots__/ContactDetails.test.tsx.snap
@@ -6,32 +6,26 @@ exports[`renders ContactDetails w/o IM 1`] = `
     className="contact-details css-47"
   >
     <li>
-      <StyledLabelBase
-        id="emailLabel"
-      >
+      <StyledLabelBase>
         Email
       </StyledLabelBase>
       <StyledLinkBase
-        aria-labelledby="emailLabel emailLink"
+        aria-label="Email user1@contoso.com"
         className="contact-link email"
         href="mailto:user1@contoso.com"
-        id="emailLink"
         onClick={[Function]}
       >
         user1@contoso.com
       </StyledLinkBase>
     </li>
     <li>
-      <StyledLabelBase
-        id="workPhoneLabel"
-      >
+      <StyledLabelBase>
         Work phone
       </StyledLabelBase>
       <StyledLinkBase
-        aria-labelledby="workPhoneLabel workPhoneLink"
+        aria-label="Work phone 555-123-4561"
         className="contact-link business-phone"
         href="tel:555-123-4561"
-        id="workPhoneLink"
         onClick={[Function]}
       >
         555-123-4561
@@ -83,48 +77,39 @@ exports[`renders full ContactDetails 1`] = `
     className="contact-details css-47"
   >
     <li>
-      <StyledLabelBase
-        id="emailLabel"
-      >
+      <StyledLabelBase>
         Email
       </StyledLabelBase>
       <StyledLinkBase
-        aria-labelledby="emailLabel emailLink"
+        aria-label="Email user1@contoso.com"
         className="contact-link email"
         href="mailto:user1@contoso.com"
-        id="emailLink"
         onClick={[Function]}
       >
         user1@contoso.com
       </StyledLinkBase>
     </li>
     <li>
-      <StyledLabelBase
-        id="chatLabel"
-      >
+      <StyledLabelBase>
         Chat
       </StyledLabelBase>
       <StyledLinkBase
-        aria-labelledby="chatLabel chatLink"
+        aria-label="Chat im-user1@contoso.com"
         className="contact-link chat"
         href="sip:im-user1@contoso.com"
-        id="chatLink"
         onClick={[Function]}
       >
         im-user1@contoso.com
       </StyledLinkBase>
     </li>
     <li>
-      <StyledLabelBase
-        id="workPhoneLabel"
-      >
+      <StyledLabelBase>
         Work phone
       </StyledLabelBase>
       <StyledLinkBase
-        aria-labelledby="workPhoneLabel workPhoneLink"
+        aria-label="Work phone 555-123-4561"
         className="contact-link business-phone"
         href="tel:555-123-4561"
-        id="workPhoneLink"
         onClick={[Function]}
       >
         555-123-4561

--- a/src/contactCard/__snapshots__/ContactDetails.test.tsx.snap
+++ b/src/contactCard/__snapshots__/ContactDetails.test.tsx.snap
@@ -6,24 +6,32 @@ exports[`renders ContactDetails w/o IM 1`] = `
     className="contact-details css-47"
   >
     <li>
-      <StyledLabelBase>
+      <StyledLabelBase
+        id="emailLabel"
+      >
         Email
       </StyledLabelBase>
       <StyledLinkBase
+        aria-labelledby="emailLabel emailLink"
         className="contact-link email"
         href="mailto:user1@contoso.com"
+        id="emailLink"
         onClick={[Function]}
       >
         user1@contoso.com
       </StyledLinkBase>
     </li>
     <li>
-      <StyledLabelBase>
+      <StyledLabelBase
+        id="workPhoneLabel"
+      >
         Work phone
       </StyledLabelBase>
       <StyledLinkBase
+        aria-labelledby="workPhoneLabel workPhoneLink"
         className="contact-link business-phone"
         href="tel:555-123-4561"
+        id="workPhoneLink"
         onClick={[Function]}
       >
         555-123-4561
@@ -75,36 +83,48 @@ exports[`renders full ContactDetails 1`] = `
     className="contact-details css-47"
   >
     <li>
-      <StyledLabelBase>
+      <StyledLabelBase
+        id="emailLabel"
+      >
         Email
       </StyledLabelBase>
       <StyledLinkBase
+        aria-labelledby="emailLabel emailLink"
         className="contact-link email"
         href="mailto:user1@contoso.com"
+        id="emailLink"
         onClick={[Function]}
       >
         user1@contoso.com
       </StyledLinkBase>
     </li>
     <li>
-      <StyledLabelBase>
+      <StyledLabelBase
+        id="chatLabel"
+      >
         Chat
       </StyledLabelBase>
       <StyledLinkBase
+        aria-labelledby="chatLabel chatLink"
         className="contact-link chat"
         href="sip:im-user1@contoso.com"
+        id="chatLink"
         onClick={[Function]}
       >
         im-user1@contoso.com
       </StyledLinkBase>
     </li>
     <li>
-      <StyledLabelBase>
+      <StyledLabelBase
+        id="workPhoneLabel"
+      >
         Work phone
       </StyledLabelBase>
       <StyledLinkBase
+        aria-labelledby="workPhoneLabel workPhoneLink"
         className="contact-link business-phone"
         href="tel:555-123-4561"
+        id="workPhoneLink"
         onClick={[Function]}
       >
         555-123-4561

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -21,12 +21,16 @@ exports[`renders Summary w/o any manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
+          aria-label="email"
           className="contact-icon"
           iconName="Mail"
+          id="emailIcon"
         />
         <StyledLinkBase
+          aria-labelledby="emailIcon emailLink"
           className="contact-link email"
           href="mailto:user1@contoso.com"
+          id="emailLink"
           onClick={[Function]}
         >
           user1@contoso.com
@@ -36,12 +40,16 @@ exports[`renders Summary w/o any manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
+          aria-label="phone"
           className="contact-icon"
           iconName="Phone"
+          id="phoneIcon"
         />
         <StyledLinkBase
+          aria-labelledby="phoneIcon phoneLink"
           className="contact-link business-phone"
           href="tel:555-123-4561"
+          id="phoneLink"
           onClick={[Function]}
         >
           555-123-4561
@@ -102,12 +110,16 @@ exports[`renders Summary with loading manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
+          aria-label="email"
           className="contact-icon"
           iconName="Mail"
+          id="emailIcon"
         />
         <StyledLinkBase
+          aria-labelledby="emailIcon emailLink"
           className="contact-link email"
           href="mailto:user1@contoso.com"
+          id="emailLink"
           onClick={[Function]}
         >
           user1@contoso.com
@@ -117,12 +129,16 @@ exports[`renders Summary with loading manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
+          aria-label="phone"
           className="contact-icon"
           iconName="Phone"
+          id="phoneIcon"
         />
         <StyledLinkBase
+          aria-labelledby="phoneIcon phoneLink"
           className="contact-link business-phone"
           href="tel:555-123-4561"
+          id="phoneLink"
           onClick={[Function]}
         >
           555-123-4561
@@ -215,12 +231,16 @@ exports[`renders full Summary 1`] = `
         className="contact-row"
       >
         <StyledIconBase
+          aria-label="email"
           className="contact-icon"
           iconName="Mail"
+          id="emailIcon"
         />
         <StyledLinkBase
+          aria-labelledby="emailIcon emailLink"
           className="contact-link email"
           href="mailto:user1@contoso.com"
+          id="emailLink"
           onClick={[Function]}
         >
           user1@contoso.com
@@ -230,12 +250,16 @@ exports[`renders full Summary 1`] = `
         className="contact-row"
       >
         <StyledIconBase
+          aria-label="phone"
           className="contact-icon"
           iconName="Phone"
+          id="phoneIcon"
         />
         <StyledLinkBase
+          aria-labelledby="phoneIcon phoneLink"
           className="contact-link business-phone"
           href="tel:555-123-4561"
+          id="phoneLink"
           onClick={[Function]}
         >
           555-123-4561

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`renders Summary w/o any manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
-          aria-label="email"
           className="contact-icon"
           iconName="Mail"
         />
@@ -38,7 +37,6 @@ exports[`renders Summary w/o any manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
-          aria-label="phone"
           className="contact-icon"
           iconName="Phone"
         />
@@ -106,7 +104,6 @@ exports[`renders Summary with loading manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
-          aria-label="email"
           className="contact-icon"
           iconName="Mail"
         />
@@ -123,7 +120,6 @@ exports[`renders Summary with loading manager 1`] = `
         className="contact-row"
       >
         <StyledIconBase
-          aria-label="phone"
           className="contact-icon"
           iconName="Phone"
         />
@@ -223,7 +219,6 @@ exports[`renders full Summary 1`] = `
         className="contact-row"
       >
         <StyledIconBase
-          aria-label="email"
           className="contact-icon"
           iconName="Mail"
         />
@@ -240,7 +235,6 @@ exports[`renders full Summary 1`] = `
         className="contact-row"
       >
         <StyledIconBase
-          aria-label="phone"
           className="contact-icon"
           iconName="Phone"
         />

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -24,13 +24,11 @@ exports[`renders Summary w/o any manager 1`] = `
           aria-label="email"
           className="contact-icon"
           iconName="Mail"
-          id="emailIcon"
         />
         <StyledLinkBase
-          aria-labelledby="emailIcon emailLink"
+          aria-label="Email user1@contoso.com"
           className="contact-link email"
           href="mailto:user1@contoso.com"
-          id="emailLink"
           onClick={[Function]}
         >
           user1@contoso.com
@@ -43,13 +41,11 @@ exports[`renders Summary w/o any manager 1`] = `
           aria-label="phone"
           className="contact-icon"
           iconName="Phone"
-          id="phoneIcon"
         />
         <StyledLinkBase
-          aria-labelledby="phoneIcon phoneLink"
+          aria-label="Phone 555-123-4561"
           className="contact-link business-phone"
           href="tel:555-123-4561"
-          id="phoneLink"
           onClick={[Function]}
         >
           555-123-4561
@@ -113,13 +109,11 @@ exports[`renders Summary with loading manager 1`] = `
           aria-label="email"
           className="contact-icon"
           iconName="Mail"
-          id="emailIcon"
         />
         <StyledLinkBase
-          aria-labelledby="emailIcon emailLink"
+          aria-label="Email user1@contoso.com"
           className="contact-link email"
           href="mailto:user1@contoso.com"
-          id="emailLink"
           onClick={[Function]}
         >
           user1@contoso.com
@@ -132,13 +126,11 @@ exports[`renders Summary with loading manager 1`] = `
           aria-label="phone"
           className="contact-icon"
           iconName="Phone"
-          id="phoneIcon"
         />
         <StyledLinkBase
-          aria-labelledby="phoneIcon phoneLink"
+          aria-label="Phone 555-123-4561"
           className="contact-link business-phone"
           href="tel:555-123-4561"
-          id="phoneLink"
           onClick={[Function]}
         >
           555-123-4561
@@ -234,13 +226,11 @@ exports[`renders full Summary 1`] = `
           aria-label="email"
           className="contact-icon"
           iconName="Mail"
-          id="emailIcon"
         />
         <StyledLinkBase
-          aria-labelledby="emailIcon emailLink"
+          aria-label="Email user1@contoso.com"
           className="contact-link email"
           href="mailto:user1@contoso.com"
-          id="emailLink"
           onClick={[Function]}
         >
           user1@contoso.com
@@ -253,13 +243,11 @@ exports[`renders full Summary 1`] = `
           aria-label="phone"
           className="contact-icon"
           iconName="Phone"
-          id="phoneIcon"
         />
         <StyledLinkBase
-          aria-labelledby="phoneIcon phoneLink"
+          aria-label="Phone 555-123-4561"
           className="contact-link business-phone"
           href="tel:555-123-4561"
-          id="phoneLink"
           onClick={[Function]}
         >
           555-123-4561


### PR DESCRIPTION
Enable the screen reader to read out the description of a link along with its anchor text for email, phone, and chat links.