### PR TITLE
Users/sichitha/improve hovercard view on zoom 400

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-contact-card",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-contact-card",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "description": "Contact Card in MS Office style",
   "repository": {
     "type": "git",

--- a/src/PersonaWithCard.scss
+++ b/src/PersonaWithCard.scss
@@ -1,5 +1,6 @@
 .persona-hover-card {
-    max-height: 100vh;
+    max-height: 90vh;
+    max-width: 90vw;
 
     .contact-card-persona {
         cursor: pointer;
@@ -8,7 +9,12 @@
     .ms-ExpandingCard-expandedCardScrollRegion {
         overflow-y: auto;
         height: 100%;
-        max-height: 60vh;
+        max-height: 70vh;
+    }
+
+    .ms-ExpandingCard-compactCard {
+        overflow: auto;
+        max-height: 40vh;
     }
 
     .back-section {
@@ -35,6 +41,7 @@
 
     .compact-card {
         padding: 20px 24px;
+        overflow: auto;
         
         .ms-Persona-secondaryText {
             font-size: 12px;

--- a/src/PersonaWithCard.tsx
+++ b/src/PersonaWithCard.tsx
@@ -73,8 +73,6 @@ export class PersonaWithCard extends React.Component<IPersonaWithCardProps, IPer
                     expandingCardProps={{
                         onRenderCompactCard: this.renderCompactCard,
                         onRenderExpandedCard: this.renderExpandedCard,
-                        compactCardHeight: this.state.cardShowMode === CardShowModes.Summary ? 145 : 145 - 60,
-                        expandedCardHeight: this.state.cardShowMode === CardShowModes.Summary ? 385 : 385 + 60
                     }}
                     onCardVisible={() => this.onCardVisible()}
                     instantOpenOnClick={true}

--- a/src/PersonaWithCard.tsx
+++ b/src/PersonaWithCard.tsx
@@ -72,7 +72,7 @@ export class PersonaWithCard extends React.Component<IPersonaWithCardProps, IPer
                 <HoverCard
                     expandingCardProps={{
                         onRenderCompactCard: this.renderCompactCard,
-                        onRenderExpandedCard: this.renderExpandedCard,
+                        onRenderExpandedCard: this.renderExpandedCard
                     }}
                     onCardVisible={() => this.onCardVisible()}
                     instantOpenOnClick={true}

--- a/src/__snapshots__/PersonaWithCard.test.tsx.snap
+++ b/src/__snapshots__/PersonaWithCard.test.tsx.snap
@@ -279,8 +279,6 @@ exports[`renders PersonaWithCard initial state 1`] = `
     className="persona-hover-card"
     expandingCardProps={
       Object {
-        "compactCardHeight": 145,
-        "expandedCardHeight": 385,
         "onRenderCompactCard": [Function],
         "onRenderExpandedCard": [Function],
       }
@@ -309,8 +307,6 @@ exports[`renders PersonaWithCard with extra props 1`] = `
     className="persona-hover-card"
     expandingCardProps={
       Object {
-        "compactCardHeight": 145,
-        "expandedCardHeight": 385,
         "onRenderCompactCard": [Function],
         "onRenderExpandedCard": [Function],
       }


### PR DESCRIPTION
This PR fixes the UI of the expanded hovercard for page zoom 400%:
- Adding a limit for the size of the header on the expanded card with overflow: auto
- Getting rid of hard-coded height values for the card