### PR TITLE
A11y: Fixed auto focus when NVDA Speech Viewer is opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-contact-card",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Contact Card in MS Office style",
   "repository": {
     "type": "git",

--- a/src/PersonaWithCard.scss
+++ b/src/PersonaWithCard.scss
@@ -46,6 +46,18 @@
         .ms-Persona-secondaryText {
             font-size: 12px;
         }
+
+        .mail-link {
+            margin-top: 4px;
+        }
+        
+        .mail-link:focus::after{
+            outline: 0px!important;
+        }
+    
+        .mail-link:focus {
+            border: black solid 1px;
+        }
     }
     
     .extended-card {

--- a/src/PersonaWithCard.tsx
+++ b/src/PersonaWithCard.tsx
@@ -77,6 +77,7 @@ export class PersonaWithCard extends React.Component<IPersonaWithCardProps, IPer
                     onCardVisible={() => this.onCardVisible()}
                     instantOpenOnClick={true}
                     trapFocus={true}
+                    setInitialFocus={true}
                     openHotKey={KeyCodes.enter}
                     className="persona-hover-card"
                     target={this.targetElementRef.current}

--- a/src/__snapshots__/PersonaWithCard.test.tsx.snap
+++ b/src/__snapshots__/PersonaWithCard.test.tsx.snap
@@ -288,6 +288,7 @@ exports[`renders PersonaWithCard initial state 1`] = `
     instantOpenOnClick={true}
     onCardVisible={[Function]}
     openHotKey={13}
+    setInitialFocus={true}
     target={null}
     trapFocus={true}
   >
@@ -316,6 +317,7 @@ exports[`renders PersonaWithCard with extra props 1`] = `
     instantOpenOnClick={true}
     onCardVisible={[Function]}
     openHotKey={13}
+    setInitialFocus={true}
     target={null}
     trapFocus={true}
   >


### PR DESCRIPTION
# Description

If the user had their NVDA speech viewer up and the Persona's were opened using keyboard focus they would not be correctly focused. Resulting in the user being unable to navigate the popped out persona using their keyboard. 

# Changes

Set the popout to automatically focus the first focusable element within the popout using `setInitialFocus={true}`

Added some css rules to ensure that the send mail button when focused would appear with an outline. 

Originally the Persona component from flutentui had some `:focus::after` rules which do not function correctly when the NVDA speech viewer is up. These temporary fixes should be punted down to them. 

This removes fluentui's focus outline
```
        .mail-link:focus::after{
            outline: 0px!important;
        }
```

While these rules are added to add the actual focus outline

```
        .mail-link:focus {
            border: black solid 1px;
        }
```

The following were added purely for aesthetic such that the border wouldn't be too close to the profile icon above it.
```
        .mail-link {
            margin-top: 4px;
        }
```
# Testing

Manual tests on edge + chrome and ran `npm test`

