### PR TITLE
A11y: Fix tab order when the contact card is open

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "office-contact-card",
-  "version": "2.0.1",
+  "version": "2.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-contact-card",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Contact Card in MS Office style",
   "repository": {
     "type": "git",

--- a/src/PersonaWithCard.tsx
+++ b/src/PersonaWithCard.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import { Persona } from "./Persona";
 import { GraphService } from "./GraphService";
 import { PersonaShowMode, IPersonaProfile } from "./Types";
-import { css, ActionButton, AnimationClassNames, FocusZone, KeyCodes, HoverCard, PersonaSize, Shimmer, TooltipHost } from "@fluentui/react";
+import { css, ActionButton, AnimationClassNames, FocusZone, KeyCodes, HoverCard, PersonaSize, Shimmer, TooltipHost, FocusZoneDirection, FocusZoneTabbableElements } from "@fluentui/react";
 import { renderContactDetails } from "./contactCard/ContactDetails";
 import { renderOrgHierarchy } from "./contactCard/OrgDetails";
 import { renderSummary } from "./contactCard/Summary";
@@ -169,14 +169,19 @@ export class PersonaWithCard extends React.Component<IPersonaWithCardProps, IPer
     private renderCompactContacts = () => {
         return this.state.profile.email &&
             (
-                <FocusZone>
+                <FocusZone
+                    direction={FocusZoneDirection.horizontal}
+                    handleTabKey={FocusZoneTabbableElements.all}>
+
                     <ActionButton iconProps={{ iconName: "Mail" }} className="mail-link" onClick={e => openLink(`mailto:${this.state.profile.email}`, e)}>
                         Send email
                     </ActionButton>
+
                     {this.state.profile.imAddress &&
-                        <TooltipHost content="Chat">
-                            <ActionButton iconProps={{ iconName: "Chat" }} className="chat-link" ariaLabel="Chat button" onClick={e => openLink(`sip:${this.state.profile.imAddress}`, e)} />
-                        </TooltipHost>}
+                        <ActionButton iconProps={{ iconName: "Chat" }} className="chat-link" onClick={e => openLink(`sip:${this.state.profile.imAddress}`, e)} >
+                            Chat
+                        </ActionButton>
+                    }
                 </FocusZone>
             );
     }

--- a/src/__snapshots__/PersonaWithCard.test.tsx.snap
+++ b/src/__snapshots__/PersonaWithCard.test.tsx.snap
@@ -13,7 +13,8 @@ exports[`renders Compact card 1`] = `
       size={14}
     />
     <FocusZone
-      direction={2}
+      direction={1}
+      handleTabKey={1}
       isCircularNavigation={false}
       shouldRaiseClicks={true}
     >
@@ -28,20 +29,17 @@ exports[`renders Compact card 1`] = `
       >
         Send email
       </CustomizedActionButton>
-      <StyledTooltipHostBase
-        content="Chat"
-      >
-        <CustomizedActionButton
-          ariaLabel="Chat button"
-          className="chat-link"
-          iconProps={
-            Object {
-              "iconName": "Chat",
-            }
+      <CustomizedActionButton
+        className="chat-link"
+        iconProps={
+          Object {
+            "iconName": "Chat",
           }
-          onClick={[Function]}
-        />
-      </StyledTooltipHostBase>
+        }
+        onClick={[Function]}
+      >
+        Chat
+      </CustomizedActionButton>
     </FocusZone>
   </div>
 </div>
@@ -60,7 +58,8 @@ exports[`renders Compact card w/o IM address 1`] = `
       size={14}
     />
     <FocusZone
-      direction={2}
+      direction={1}
+      handleTabKey={1}
       isCircularNavigation={false}
       shouldRaiseClicks={true}
     >
@@ -362,7 +361,8 @@ exports[`renders next Person 1`] = `
       size={14}
     />
     <FocusZone
-      direction={2}
+      direction={1}
+      handleTabKey={1}
       isCircularNavigation={false}
       shouldRaiseClicks={true}
     >
@@ -377,20 +377,17 @@ exports[`renders next Person 1`] = `
       >
         Send email
       </CustomizedActionButton>
-      <StyledTooltipHostBase
-        content="Chat"
-      >
-        <CustomizedActionButton
-          ariaLabel="Chat button"
-          className="chat-link"
-          iconProps={
-            Object {
-              "iconName": "Chat",
-            }
+      <CustomizedActionButton
+        className="chat-link"
+        iconProps={
+          Object {
+            "iconName": "Chat",
           }
-          onClick={[Function]}
-        />
-      </StyledTooltipHostBase>
+        }
+        onClick={[Function]}
+      >
+        Chat
+      </CustomizedActionButton>
     </FocusZone>
   </div>
 </div>
@@ -409,7 +406,8 @@ exports[`renders prev Person 1`] = `
       size={14}
     />
     <FocusZone
-      direction={2}
+      direction={1}
+      handleTabKey={1}
       isCircularNavigation={false}
       shouldRaiseClicks={true}
     >
@@ -424,20 +422,17 @@ exports[`renders prev Person 1`] = `
       >
         Send email
       </CustomizedActionButton>
-      <StyledTooltipHostBase
-        content="Chat"
-      >
-        <CustomizedActionButton
-          ariaLabel="Chat button"
-          className="chat-link"
-          iconProps={
-            Object {
-              "iconName": "Chat",
-            }
+      <CustomizedActionButton
+        className="chat-link"
+        iconProps={
+          Object {
+            "iconName": "Chat",
           }
-          onClick={[Function]}
-        />
-      </StyledTooltipHostBase>
+        }
+        onClick={[Function]}
+      >
+        Chat
+      </CustomizedActionButton>
     </FocusZone>
   </div>
 </div>


### PR DESCRIPTION
### Description 
When the user clicks on a person's contact card and starts navigating through the buttons using keyboard tab, the chat button is inaccessible. The focus goes from the "Send Email" button directly to the "Contact" button which is incorrect.

### Changes

Before:
![image](https://user-images.githubusercontent.com/8295932/126543847-173c2f5c-1aaa-400b-b239-c8fc99415d1d.png)

After:
![image](https://user-images.githubusercontent.com/8295932/126559531-3b369fd0-6fce-4a71-b6b1-03f5343d59b9.png)

The chat button does not function as a tooltip with this change just so that the button looks consistent with the "Send Email" button. Also upgraded the package version from 2.1.0 to 2.2.0.

