### PR TITLE
Small fix Screen reader show more button expanded

### DIFF
--- a/src/contactCard/Summary.test.tsx
+++ b/src/contactCard/Summary.test.tsx
@@ -8,19 +8,19 @@ import { openLink } from "../Tools";
 
 
 test("renders full Summary", () => {
-    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), buildProfile(2), false, jest.fn(), jest.fn(), jest.fn())}</div>);
+    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), buildProfile(2), false, true, jest.fn(), jest.fn(), jest.fn())}</div>);
     expect(wrap).toMatchSnapshot();
 });
 
 
 test("renders Summary with loading manager", () => {
-    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, true, jest.fn(), jest.fn(), jest.fn())}</div>);
+    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, true, true, jest.fn(), jest.fn(), jest.fn())}</div>);
     expect(wrap).toMatchSnapshot();
 });
 
 
 test("renders Summary w/o any manager", () => {
-    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, false, jest.fn(), jest.fn(), jest.fn())}</div>);
+    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, false, true, jest.fn(), jest.fn(), jest.fn())}</div>);
     expect(wrap).toMatchSnapshot();
 });
 

--- a/src/contactCard/Summary.test.tsx
+++ b/src/contactCard/Summary.test.tsx
@@ -8,19 +8,19 @@ import { openLink } from "../Tools";
 
 
 test("renders full Summary", () => {
-    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), buildProfile(2), false, true, jest.fn(), jest.fn(), jest.fn())}</div>);
+    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), buildProfile(2), false, jest.fn(), jest.fn(), jest.fn())}</div>);
     expect(wrap).toMatchSnapshot();
 });
 
 
 test("renders Summary with loading manager", () => {
-    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, true, true, jest.fn(), jest.fn(), jest.fn())}</div>);
+    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, true, jest.fn(), jest.fn(), jest.fn())}</div>);
     expect(wrap).toMatchSnapshot();
 });
 
 
 test("renders Summary w/o any manager", () => {
-    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, false, true, jest.fn(), jest.fn(), jest.fn())}</div>);
+    const wrap = Enzyme.shallow(<div>{renderSummary(buildProfile(1), undefined, false, jest.fn(), jest.fn(), jest.fn())}</div>);
     expect(wrap).toMatchSnapshot();
 });
 

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -45,7 +45,7 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
                 <span>{profile.officeLocation}</span>
                 <span>&nbsp;{profile.city}</span>
             </div>
-            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick}>
+            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-expanded={true}>
                 Show more
             </ActionButton>
         </li>

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -67,6 +67,7 @@ exports[`renders Summary w/o any manager 1`] = `
       <CustomizedActionButton
         className="more-details contact-details"
         onClick={[MockFunction]}
+        aria-expanded={true}
       >
         Show more
       </CustomizedActionButton>
@@ -150,6 +151,7 @@ exports[`renders Summary with loading manager 1`] = `
       <CustomizedActionButton
         className="more-details contact-details"
         onClick={[MockFunction]}
+        aria-expanded={true}
       >
         Show more
       </CustomizedActionButton>
@@ -265,6 +267,7 @@ exports[`renders full Summary 1`] = `
       <CustomizedActionButton
         className="more-details contact-details"
         onClick={[MockFunction]}
+        aria-expanded={true}
       >
         Show more
       </CustomizedActionButton>

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -76,6 +76,7 @@ exports[`renders Summary w/o any manager 1`] = `
       <CustomizedActionButton
         className="more-details org-details"
         onClick={[MockFunction]}
+        aria-expanded={true}
       >
         Show organization
       </CustomizedActionButton>
@@ -160,6 +161,7 @@ exports[`renders Summary with loading manager 1`] = `
       <CustomizedActionButton
         className="section-title org-details-button"
         onClick={[MockFunction]}
+        aria-expanded={true}
       >
         Reports to 
         <Icon
@@ -276,6 +278,7 @@ exports[`renders full Summary 1`] = `
       <CustomizedActionButton
         className="section-title org-details-button"
         onClick={[MockFunction]}
+        aria-expanded={true}
       >
         Reports to 
         <Icon


### PR DESCRIPTION
In the product catalog page after hitting enter on "show More" button Narrator should read that the button has expanded. Added aria label to fix the issue. 

Testing Details
1.Verified and checked the changes to reflect in the UI locally.
2.Verified all unit tests snapshots have passed locally
3.Verified to check if there are no additional issues due to the UI Change by running Accessibility insights locally.