### PR TITLE
A11y bug

### DIFF
--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -25,9 +25,6 @@ export function renderSummary(
 function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: () => void): React.ReactNode {
     return (
         <li>
-            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-label="Show more" aria-expanded={true} tabIndex={0}>
-                Show more
-            </ActionButton>
             <ActionButton className="section-title contact-details-button" onClick={onContactDetailsClick}>
                 Contact <Icon iconName="ChevronRight" className="chevron-icon" />
             </ActionButton>
@@ -48,6 +45,9 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
                 <span>{profile.officeLocation}</span>
                 <span>&nbsp;{profile.city}</span>
             </div>
+            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-label="Show more" aria-expanded={true}>
+                Show more
+            </ActionButton>
         </li>
     );
 }

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -25,6 +25,9 @@ export function renderSummary(
 function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: () => void): React.ReactNode {
     return (
         <li>
+            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-label="Show more" aria-expanded={true} tabIndex={0}>
+                Show more
+            </ActionButton>
             <ActionButton className="section-title contact-details-button" onClick={onContactDetailsClick}>
                 Contact <Icon iconName="ChevronRight" className="chevron-icon" />
             </ActionButton>
@@ -45,9 +48,6 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
                 <span>{profile.officeLocation}</span>
                 <span>&nbsp;{profile.city}</span>
             </div>
-            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-label="Show more" aria-expanded={true}>
-                Show more
-            </ActionButton>
         </li>
     );
 }

--- a/src/contactCard/Summary.tsx
+++ b/src/contactCard/Summary.tsx
@@ -45,7 +45,7 @@ function renderContactSummary(profile: IPersonaProfile, onContactDetailsClick: (
                 <span>{profile.officeLocation}</span>
                 <span>&nbsp;{profile.city}</span>
             </div>
-            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-label="Show more" aria-expanded={true}>
+            <ActionButton className="more-details contact-details" onClick={onContactDetailsClick} aria-label="Show more" aria-expanded={true} tabIndex={0}>
                 Show more
             </ActionButton>
         </li>

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -8,6 +8,15 @@ exports[`renders Summary w/o any manager 1`] = `
   >
     <li>
       <CustomizedActionButton
+        aria-expanded={true}
+        aria-label="Show more"
+        className="more-details contact-details"
+        onClick={[MockFunction]}
+        tabIndex={0}
+      >
+        Show more
+      </CustomizedActionButton>
+      <CustomizedActionButton
         className="section-title contact-details-button"
         onClick={[MockFunction]}
       >
@@ -64,14 +73,6 @@ exports[`renders Summary w/o any manager 1`] = `
           Redmond
         </span>
       </div>
-      <CustomizedActionButton
-        aria-expanded={true}
-        aria-label="Show more"
-        className="more-details contact-details"
-        onClick={[MockFunction]}
-      >
-        Show more
-      </CustomizedActionButton>
     </li>
     <li>
       <CustomizedActionButton
@@ -93,6 +94,15 @@ exports[`renders Summary with loading manager 1`] = `
   >
     <li>
       <CustomizedActionButton
+        aria-expanded={true}
+        aria-label="Show more"
+        className="more-details contact-details"
+        onClick={[MockFunction]}
+        tabIndex={0}
+      >
+        Show more
+      </CustomizedActionButton>
+      <CustomizedActionButton
         className="section-title contact-details-button"
         onClick={[MockFunction]}
       >
@@ -149,14 +159,6 @@ exports[`renders Summary with loading manager 1`] = `
           Redmond
         </span>
       </div>
-      <CustomizedActionButton
-        aria-expanded={true}
-        aria-label="Show more"
-        className="more-details contact-details"
-        onClick={[MockFunction]}
-      >
-        Show more
-      </CustomizedActionButton>
     </li>
     <li>
       <CustomizedActionButton
@@ -210,6 +212,15 @@ exports[`renders full Summary 1`] = `
   >
     <li>
       <CustomizedActionButton
+        aria-expanded={true}
+        aria-label="Show more"
+        className="more-details contact-details"
+        onClick={[MockFunction]}
+        tabIndex={0}
+      >
+        Show more
+      </CustomizedActionButton>
+      <CustomizedActionButton
         className="section-title contact-details-button"
         onClick={[MockFunction]}
       >
@@ -266,14 +277,6 @@ exports[`renders full Summary 1`] = `
           Redmond
         </span>
       </div>
-      <CustomizedActionButton
-        aria-expanded={true}
-        aria-label="Show more"
-        className="more-details contact-details"
-        onClick={[MockFunction]}
-      >
-        Show more
-      </CustomizedActionButton>
     </li>
     <li>
       <CustomizedActionButton

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -8,15 +8,6 @@ exports[`renders Summary w/o any manager 1`] = `
   >
     <li>
       <CustomizedActionButton
-        aria-expanded={true}
-        aria-label="Show more"
-        className="more-details contact-details"
-        onClick={[MockFunction]}
-        tabIndex={0}
-      >
-        Show more
-      </CustomizedActionButton>
-      <CustomizedActionButton
         className="section-title contact-details-button"
         onClick={[MockFunction]}
       >
@@ -73,6 +64,14 @@ exports[`renders Summary w/o any manager 1`] = `
           Redmond
         </span>
       </div>
+      <CustomizedActionButton
+        aria-expanded={true}
+        aria-label="Show more"
+        className="more-details contact-details"
+        onClick={[MockFunction]}
+      >
+        Show more
+      </CustomizedActionButton>
     </li>
     <li>
       <CustomizedActionButton
@@ -94,15 +93,6 @@ exports[`renders Summary with loading manager 1`] = `
   >
     <li>
       <CustomizedActionButton
-        aria-expanded={true}
-        aria-label="Show more"
-        className="more-details contact-details"
-        onClick={[MockFunction]}
-        tabIndex={0}
-      >
-        Show more
-      </CustomizedActionButton>
-      <CustomizedActionButton
         className="section-title contact-details-button"
         onClick={[MockFunction]}
       >
@@ -159,6 +149,14 @@ exports[`renders Summary with loading manager 1`] = `
           Redmond
         </span>
       </div>
+      <CustomizedActionButton
+        aria-expanded={true}
+        aria-label="Show more"
+        className="more-details contact-details"
+        onClick={[MockFunction]}
+      >
+        Show more
+      </CustomizedActionButton>
     </li>
     <li>
       <CustomizedActionButton
@@ -212,15 +210,6 @@ exports[`renders full Summary 1`] = `
   >
     <li>
       <CustomizedActionButton
-        aria-expanded={true}
-        aria-label="Show more"
-        className="more-details contact-details"
-        onClick={[MockFunction]}
-        tabIndex={0}
-      >
-        Show more
-      </CustomizedActionButton>
-      <CustomizedActionButton
         className="section-title contact-details-button"
         onClick={[MockFunction]}
       >
@@ -277,6 +266,14 @@ exports[`renders full Summary 1`] = `
           Redmond
         </span>
       </div>
+      <CustomizedActionButton
+        aria-expanded={true}
+        aria-label="Show more"
+        className="more-details contact-details"
+        onClick={[MockFunction]}
+      >
+        Show more
+      </CustomizedActionButton>
     </li>
     <li>
       <CustomizedActionButton

--- a/src/contactCard/__snapshots__/Summary.test.tsx.snap
+++ b/src/contactCard/__snapshots__/Summary.test.tsx.snap
@@ -69,6 +69,7 @@ exports[`renders Summary w/o any manager 1`] = `
         aria-label="Show more"
         className="more-details contact-details"
         onClick={[MockFunction]}
+        tabIndex={0}
       >
         Show more
       </CustomizedActionButton>
@@ -154,6 +155,7 @@ exports[`renders Summary with loading manager 1`] = `
         aria-label="Show more"
         className="more-details contact-details"
         onClick={[MockFunction]}
+        tabIndex={0}
       >
         Show more
       </CustomizedActionButton>
@@ -271,6 +273,7 @@ exports[`renders full Summary 1`] = `
         aria-label="Show more"
         className="more-details contact-details"
         onClick={[MockFunction]}
+        tabIndex={0}
       >
         Show more
       </CustomizedActionButton>


### PR DESCRIPTION
Added a tabIndex so that the screen reader announces the order of the elements when the user navigates using the keyboard on the "show more" button.

Please check the latest commit. I have moved "show more button" element from bottom to the top of the function mistakenly in previous commit which i moved back to the bottom in my latest commit.